### PR TITLE
Version 1.8.6

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+Version 1.8.6
+  * xiSEARCH version gets forwarded to xiFDR (if >= 2.3.1)
+  * BugFix: linear peptide matches where exported with two columns missing (from the empty peptide2 columns)
 
 Version 1.8.5
   * better detection java version

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>rappsilber</groupId>
     <artifactId>xiSEARCH</artifactId>
-    <version>1.8.5</version>
+    <version>1.8.6</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
@@ -112,5 +112,5 @@
             </plugin>          
         </plugins>    
     </build>
-    <name>xiSEARCH 1.8.5</name>
+    <name>xiSEARCH 1.8.6</name>
 </project>

--- a/src/main/java/rappsilber/gui/SimpleXiGui.java
+++ b/src/main/java/rappsilber/gui/SimpleXiGui.java
@@ -52,6 +52,7 @@ import java.util.logging.Filter;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPOutputStream;
 import javax.swing.JEditorPane;
@@ -119,6 +120,7 @@ public class SimpleXiGui extends javax.swing.JFrame {
     String propertyAddress = "mzIdenMLOwnerAddress";
     String propertyOrg = "mzIdenMLOwnerOrg";
     String propertyLastXiVersion = "lastxiversion";
+    private Version xifdr_version;
     
 
     private class FDRInfo {
@@ -696,6 +698,7 @@ public class SimpleXiGui extends javax.swing.JFrame {
             this.tpMain.setSelectedComponent(this.pAbout);
         }
         LocalProperties.setProperty(propertyLastXiVersion, current.toString());
+        fbXIFDRFocusLost(null);
     }
 
     private static int getJavaMajorVersion() {
@@ -804,6 +807,10 @@ public class SimpleXiGui extends javax.swing.JFrame {
             if (fdr.boostBetween) {
                 args.add("--boost-between");
             }
+        }
+        
+        if (xifdr_version.compareTo(new Version("2.3.1")) >= 0 ) {
+            args.add("--xiversion=" + XiVersion.getVersionString());
         }
         
         if (ckWriteMZID.isEnabled() && ckWriteMZID.isSelected()) {
@@ -2319,8 +2326,16 @@ public class SimpleXiGui extends javax.swing.JFrame {
     }//GEN-LAST:event_formWindowClosing
 
     private void fbXIFDRFocusLost(java.awt.event.FocusEvent evt) {//GEN-FIRST:event_fbXIFDRFocusLost
-        boolean mzEn = ckFDR.isSelected() && !(fbXIFDR.getText().contains("-1.") |
-                fbXIFDR.getText().contains("-2.1"));
+        String xiFDR = fbXIFDR.getText();
+        boolean mzEn = ckFDR.isSelected() && !(xiFDR.contains("-1.") |
+                xiFDR.contains("-2.1"));
+        if (!xiFDR.isEmpty()) {
+            Pattern p  = Pattern.compile(".*-([0-9]\\.[0-9]*[^\\-]*).*.jar");
+            Matcher m = p.matcher(xiFDR);
+            if (m.matches()) {
+                this.xifdr_version = new Version(m.group(1));
+            }
+        }
         ckWriteMZID.setEnabled(mzEn);
         mzEn &= ckWriteMZID.isSelected();
         txtMZIDAddress.setEditable(mzEn);

--- a/src/main/java/rappsilber/ms/dataAccess/output/CSVExportMatches.java
+++ b/src/main/java/rappsilber/ms/dataAccess/output/CSVExportMatches.java
@@ -466,7 +466,7 @@ public class CSVExportMatches extends AbstractResultWriter implements ResultWrit
                     delimChar +
                     delimChar +
                     delimChar +
-                    ",,,,,,,,,,,,,".replace(",", ""+delimChar)
+                    ",,,,,,,,,,,,,,,".replace(",", ""+delimChar)
                     ;
         }
     }

--- a/src/main/java/rappsilber/ms/lookup/peptides/FUPeptideTree.java
+++ b/src/main/java/rappsilber/ms/lookup/peptides/FUPeptideTree.java
@@ -73,7 +73,7 @@ public class FUPeptideTree extends Double2ObjectRBTreeMap<PeptideLookupElement> 
                 return;
             }
             
-            Double mass = pep.getMass();
+            double mass = pep.getMass();
             PeptideLookupElement e;
             if (this.containsKey(mass)) {
                 e = this.get(mass);

--- a/src/main/java/rappsilber/utils/XiVersion.java
+++ b/src/main/java/rappsilber/utils/XiVersion.java
@@ -28,6 +28,9 @@ public class XiVersion {
     public static org.rappsilber.utils.Version version = org.rappsilber.utils.Version.parseEmbededVersion("xiSEARCH.properties", "xiSEARCH.version");
     
     public static final String changes = 
+                                "Version 1.8.6\n" +
+                                "  * xiSEARCH version gets forwarded to xiFDR (if >= 2.3.1)\n" +
+                                "  * BugFix: linear peptide matches where exported with two columns missing (from the empty peptide2 columns)\n" +
                                 "Version 1.8.5\n" +
                                 "  * better detection java version\n" +
                                 "  * better detection of the used java binary\n" +


### PR DESCRIPTION
  * xiSEARCH version gets forwarded to xiFDR (if >= 2.3.1)
  * BugFix: linear peptide matches where exported with two columns missing (from the empty peptide2 columns)